### PR TITLE
Fix GoReleaser action version for v2 format support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: go test -v ./...
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
## Summary

This PR fixes the release workflow failure by updating the GoReleaser action from v5 to v6 to support the v2 configuration format.

## Problem

The release workflow failed with:
```
error=only configurations files on version: 1 are supported, yours is version: 2, please update your configuration
```

## Solution

- Updated `goreleaser/goreleaser-action` from `@v5` to `@v6`
- This version supports GoReleaser v2 configuration format used in our `.goreleaser.yml`

## Changes

- `.github/workflows/release.yml`: Updated GoReleaser action version

## Test Plan

- [ ] Tag a test release to verify the workflow works
- [ ] Confirm binaries are generated for all platforms
- [ ] Verify release artifacts are properly uploaded

## Notes

This is a minimal fix that addresses the specific version compatibility issue without changing the GoReleaser configuration format.
